### PR TITLE
Update wirenet_dropper.yar

### DIFF
--- a/droppers/wirenet_dropper.yar
+++ b/droppers/wirenet_dropper.yar
@@ -7,10 +7,10 @@ meta:
   date = "2017/07/11"
   hash = "954d7c15577f118171cc8adcc9f9ac94"
 strings:
-$a = "C:\Users\user\Desktop\JAVA\docinvoice.exe"
-$b = "C:\Users\user\AppData\Local\Temp\docinvoice.exe"
+$a = "C:\\Users\\user\\Desktop\\JAVA\\docinvoice.exe"
+$b = "C:\\Users\\user\\AppData\\Local\\Temp\\docinvoice.exe"
 $c = "ZTUWVSPRTj"
-$d = "IE(AL("%s",4),"AL(\"%0:s\",3)""
+$d = "IE(AL(\"%s\",4),\"AL(\"%0:s\",3)"
 condition:
-  all of them 
-} 
+  all of them
+}


### PR DESCRIPTION
Escaped the double quotes in the $d string pattern and deleted the extra trailing double quote. Also escaped the slashes in the paths for the first two string patterns. Full disclosure: I do not have a sample to validate these changes with, but yarac could not compile this rule until I fixed those syntax issues.